### PR TITLE
Fix major flaw in mqtt authentication logic

### DIFF
--- a/src/mqttclient/Mqtt/Mqtt.cs
+++ b/src/mqttclient/Mqtt/Mqtt.cs
@@ -87,7 +87,7 @@ namespace mqttclient.Mqtt
 
                         _client = new MqttClient(hostname, portNumber, false, null, null, MqttSslProtocols.None, null);
 
-                        if (!Helpers.IsEmptyOrWhitespaced(username))
+                        if (Helpers.IsEmptyOrWhitespaced(username))
                         {
                             byte code = _client.Connect(Guid.NewGuid().ToString());
                         }


### PR DESCRIPTION
So far - if you specify username and your mqtt server uses username/password authentication - it won't authenticate. 

Reason - edited condition was incorrectly inversed.